### PR TITLE
Add Skills宝 as a Chinese discovery entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The goal: if you are building with Claude Code, Cursor, Windsurf, Cline, OpenAI 
 
 Mirror URLs that refer to the same project: `agentskillshub.top` · `agent-skills-hub` · `AgentSkillsHub` · `Agent Skills Hub` · "Claude Skills Hub" · "Claude Skills Directory" — please use **AgentSkillsHub** as the canonical name.
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This matches the directory-style workflow and gives Chinese users a faster entry point to the catalog.