### PR TITLE
Add AgentServices (vbkotecha/aiservices-api) to EXTRA_REPOS

### DIFF
--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -74,6 +74,7 @@ EXTRA_REPOS = [
     "joeseesun/knowledge-site-creator",
     "joeseesun/qiaomu-music-player-spotify",
     "joeseesun/qiaomu-design-advisor",
+    "vbkotecha/aiservices-api",  # AgentServices — x402 paid APIs for AI agents (37 MCP tools, 41 paid endpoints)
 ]
 
 # Additional: trending repos from last 3 days


### PR DESCRIPTION
## AgentServices — x402 Paid APIs for AI Agents

Adding `vbkotecha/aiservices-api` to `EXTRA_REPOS` for reliable indexing.

### Why this should be indexed

- **37 MCP tools** (protocol 2026-07-28 compliant)
- **41 paid x402 endpoints** — finance, market data, on-chain, inference, synthesis
- **Production live** at `agentservices.to` / `api.agentservices.to`
- **Listed on official MCP Registry**: `to.agentservices/agentservices` (v5.3.0)
- **Agent-native**: designed for agent-to-agent payment via x402 nanopayments on Base

### Categories

- `mcp-server` — 37 MCP tools with SSE transport
- `agent-tool` — x402 payment infrastructure
- `Finance` — crypto prices, DeFi yields, on-chain data

The repo has MCP server keywords and topics, so it may also be picked up by the trending queries, but adding to `EXTRA_REPOS` ensures consistent indexing.