### PR TITLE
Add youdotcom-oss/agent-skills to EXTRA_REPOS

### DIFF
--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -111,6 +111,10 @@ EXTRA_REPOS = [
     "laolin5564/openclaw-wx-echo",
     # seo-audit-skill - SEO audit agent skill with HTML reports (248 stars)
     "JeffLi1993/seo-audit-skill",
+    # You.com official Agent Skills - web search, research, finance, and
+    # integration-discovery skills + MCP server configs for Claude Code,
+    # Codex, Cursor, Copilot CLI, Kimi Code, OpenCode, OpenClaw, Pi, Hermes
+    "youdotcom-oss/agent-skills",
 ]
 
 # ── Rate Limit Management ──


### PR DESCRIPTION
Adding You.com's official agent-skills repo to the manually curated `EXTRA_REPOS` list so it gets picked up reliably in the next sync.

## What it is

[youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) is You.com's official skills repo (MIT). It packages five skills — `you-web` (web search, URL reading, cited synthesis), `you-research`, `you-finance`, `you-discover` (integration planning), and `you-free` (keyless basic search) — plus MCP server configs for Claude Code, Codex, Cursor, Copilot CLI, Kimi Code, OpenCode, OpenClaw, Pi, and Hermes:

```bash
npx skills add youdotcom-oss/agent-skills
```

It fits the directory's `claude-skill` / `agent-tool` / `mcp-server` categories and is directly relevant to the web-search scenario pages.

## The change

One entry + comment in `backend/app/scheduler/jobs.py`, following the existing entries (e.g. `cloudflare/skills`, `teng-lin/agent-fetch`). Nothing else touched — the next 8-hour sync should fetch, classify, score, and security-grade it like any other curated repo.

## Validation

- `python -m py_compile app/scheduler/jobs.py` passes
- Parsed `EXTRA_REPOS` with ast: 27 entries, no duplicates, new entry present
- `ruff check --config backend/ruff.toml app/scheduler/jobs.py`: identical 47 pre-existing baseline errors before and after the change (none introduced)

Happy to also submit it through the Submit Skill form instead if you'd rather keep the code list for maintainers-only entries — the PR felt more transparent since it lands directly in the sync pipeline.